### PR TITLE
ci: build Windows x86-64 releases with MSVC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,10 @@ on:
 
 env:
   IDA_SDK_REPO: HexRaysSA/ida-sdk
-  # Match idax's reproducible IDA 9.4.0 release-patch SDK pin.
-  IDA_SDK_STABLE_REF: 6929db6868a524496eb66e76e4ec6c9d720a0594
+  # Build against the base IDA 9.4.0 release ABI. The later SDK release patch
+  # redirects find_reg_value_info() to reg_finder94_find_reg_value_info(), an
+  # export absent from IDA 9.4 build 260713 and other pre-patch installations.
+  IDA_SDK_STABLE_REF: f45fa5149caac89a954d1d82cd9d76b3899ee6a6
   XWIN_VERSION: 0.8.0
 
 permissions:
@@ -76,6 +78,12 @@ jobs:
           - os: ubuntu-24.04-arm
             name: linux-arm64
             rust_target: aarch64-unknown-linux-gnu
+            ida_branch: ""
+            ida_suffix: ""
+          - os: windows-latest
+            name: windows-x86_64
+            cmake_arch: x64
+            rust_target: x86_64-pc-windows-msvc
             ida_branch: ""
             ida_suffix: ""
           - os: windows-11-arm
@@ -186,11 +194,24 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
-      - name: Configure CMake (Windows ARM64)
+      - name: Configure CMake (Windows MSVC)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           cmake -S . -B build -A "${{ matrix.cmake_arch }}" -DBUILD_TESTING=OFF
+
+          $compilerMetadata = @(
+            Get-ChildItem -Path build -Recurse -Filter CMakeCXXCompiler.cmake -File
+          )
+          if ($compilerMetadata.Count -eq 0) {
+            throw "CMake did not generate C++ compiler metadata"
+          }
+          $compilerDescription = $compilerMetadata |
+            ForEach-Object { Get-Content -LiteralPath $_.FullName -Raw } |
+            Out-String
+          if ($compilerDescription -notmatch 'CMAKE_CXX_COMPILER_ID "MSVC"') {
+            throw "Windows release artifacts must be compiled with native MSVC"
+          }
 
       - name: Build (Unix)
         if: runner.os != 'Windows'
@@ -198,7 +219,7 @@ jobs:
           parallelism="$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
           cmake --build build --config Release --parallel "$parallelism"
 
-      - name: Build (Windows ARM64)
+      - name: Build (Windows MSVC)
         if: runner.os == 'Windows'
         shell: pwsh
         run: cmake --build build --config Release --parallel $env:NUMBER_OF_PROCESSORS
@@ -249,9 +270,9 @@ jobs:
           printf '%s\n' "plugin_file=$PLUGIN_FILE" >> "$GITHUB_OUTPUT"
           printf '%s\n' "extension=so" >> "$GITHUB_OUTPUT"
 
-      - name: Find built plugin (Windows ARM64)
+      - name: Find and verify built plugin (Windows MSVC)
         if: runner.os == 'Windows'
-        id: find_plugin_windows_arm64
+        id: find_plugin_windows
         shell: pwsh
         run: |
           $pluginFile = "$env:IDASDK/src/bin/plugins/chernobog.dll"
@@ -261,19 +282,18 @@ jobs:
             throw "Could not find built plugin at $pluginFile"
           }
 
-          # IMAGE_FILE_MACHINE_ARM64 = 0xAA64. Verify the release artifact is
-          # not an emulated or accidentally cross-selected x86-64 binary.
-          $bytes = [System.IO.File]::ReadAllBytes($pluginFile)
-          if ($bytes.Length -lt 64) {
-            throw "Built plugin is too small to contain a PE header"
+          $expectedMachine = switch ("${{ matrix.name }}") {
+            'windows-x86_64' { 'amd64' }
+            'windows-arm64' { 'arm64' }
+            default { throw "No PE machine mapping for ${{ matrix.name }}" }
           }
-          $peOffset = [BitConverter]::ToInt32($bytes, 0x3c)
-          if ($peOffset -lt 0 -or $peOffset + 6 -gt $bytes.Length) {
-            throw "Built plugin has an invalid PE header offset"
-          }
-          $machine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
-          if ($machine -ne 0xAA64) {
-            throw ('Built plugin PE machine is 0x{0:X4}; expected ARM64 (0xAA64)' -f $machine)
+          python tests/verify_windows_pe.py $pluginFile `
+            --machine $expectedMachine `
+            --require-import 'ida.dll!find_reg_value_info' `
+            --forbid-import 'ida.dll!reg_finder94_find_reg_value_info' `
+            --require-export PLUGIN
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows PE verification failed"
           }
 
           "plugin_file=$pluginFile" |
@@ -293,12 +313,12 @@ jobs:
           mkdir -p artifacts
           cp "${{ steps.find_plugin_linux.outputs.plugin_file }}" "artifacts/chernobog${{ matrix.ida_suffix }}_${{ matrix.name }}.${{ steps.find_plugin_linux.outputs.extension }}"
 
-      - name: Prepare artifact (Windows ARM64)
+      - name: Prepare artifact (Windows MSVC)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
-          Copy-Item -LiteralPath "${{ steps.find_plugin_windows_arm64.outputs.plugin_file }}" -Destination "artifacts/chernobog${{ matrix.ida_suffix }}_${{ matrix.name }}.${{ steps.find_plugin_windows_arm64.outputs.extension }}"
+          Copy-Item -LiteralPath "${{ steps.find_plugin_windows.outputs.plugin_file }}" -Destination "artifacts/chernobog${{ matrix.ida_suffix }}_${{ matrix.name }}.${{ steps.find_plugin_windows.outputs.extension }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -308,9 +328,10 @@ jobs:
           retention-days: 30
 
   build-windows-cross:
+    if: github.event_name == 'workflow_dispatch'
     needs: validate-source
     runs-on: ubuntu-latest
-    name: Build windows-x86_64-clang
+    name: Build windows-x86_64-clang (manual compatibility check)
 
     steps:
       - name: Checkout repository
@@ -483,7 +504,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build, build-windows-cross]
+    needs: [build]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,12 @@ on:
 
 env:
   IDA_SDK_REPO: HexRaysSA/ida-sdk
-  # Build against the base IDA 9.4.0 release ABI. The later SDK release patch
-  # redirects find_reg_value_info() to reg_finder94_find_reg_value_info(), an
-  # export absent from IDA 9.4 build 260713 and other pre-patch installations.
-  IDA_SDK_STABLE_REF: f45fa5149caac89a954d1d82cd9d76b3899ee6a6
+  # Unix builds use the current 9.4 SDK patch and its matching runtime stubs.
+  IDA_SDK_STABLE_REF: 6929db6868a524496eb66e76e4ec6c9d720a0594
+  # Windows release DLLs retain the base 9.4 ABI. The later patch redirects
+  # find_reg_value_info() to reg_finder94_find_reg_value_info(), an export
+  # absent from IDA 9.4 build 260713 and other pre-patch installations.
+  IDA_SDK_WINDOWS_COMPAT_REF: f45fa5149caac89a954d1d82cd9d76b3899ee6a6
   XWIN_VERSION: 0.8.0
 
 permissions:
@@ -62,34 +64,40 @@ jobs:
             name: macos-x86_64
             cmake_arch: x86_64
             rust_target: x86_64-apple-darwin
+            ida_sdk_ref: 6929db6868a524496eb66e76e4ec6c9d720a0594
             ida_branch: ""
             ida_suffix: ""
           - os: macos-latest
             name: macos-arm64
             cmake_arch: arm64
             rust_target: aarch64-apple-darwin
+            ida_sdk_ref: 6929db6868a524496eb66e76e4ec6c9d720a0594
             ida_branch: ""
             ida_suffix: ""
           - os: ubuntu-latest
             name: linux-x86_64
             rust_target: x86_64-unknown-linux-gnu
+            ida_sdk_ref: 6929db6868a524496eb66e76e4ec6c9d720a0594
             ida_branch: ""
             ida_suffix: ""
           - os: ubuntu-24.04-arm
             name: linux-arm64
             rust_target: aarch64-unknown-linux-gnu
+            ida_sdk_ref: 6929db6868a524496eb66e76e4ec6c9d720a0594
             ida_branch: ""
             ida_suffix: ""
           - os: windows-latest
             name: windows-x86_64
             cmake_arch: x64
             rust_target: x86_64-pc-windows-msvc
+            ida_sdk_ref: f45fa5149caac89a954d1d82cd9d76b3899ee6a6
             ida_branch: ""
             ida_suffix: ""
           - os: windows-11-arm
             name: windows-arm64
             cmake_arch: ARM64
             rust_target: aarch64-pc-windows-msvc
+            ida_sdk_ref: f45fa5149caac89a954d1d82cd9d76b3899ee6a6
             ida_branch: ""
             ida_suffix: ""
 
@@ -114,7 +122,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: ${{ env.IDA_SDK_REPO }}
-          ref: ${{ env.IDA_SDK_STABLE_REF }}
+          ref: ${{ matrix.ida_sdk_ref }}
           path: ida-sdk
           submodules: recursive
 
@@ -144,18 +152,18 @@ jobs:
         uses: actions/cache@v6
         with:
           path: build
-          key: build-v3-${{ runner.os }}-${{ matrix.name }}-${{ env.IDA_SDK_STABLE_REF }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', '.github/workflows/build.yml') }}-${{ hashFiles('src/**') }}
+          key: build-v3-${{ runner.os }}-${{ matrix.name }}-${{ matrix.ida_sdk_ref }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', '.github/workflows/build.yml') }}-${{ hashFiles('src/**') }}
           restore-keys: |
-            build-v3-${{ runner.os }}-${{ matrix.name }}-${{ env.IDA_SDK_STABLE_REF }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', '.github/workflows/build.yml') }}-
+            build-v3-${{ runner.os }}-${{ matrix.name }}-${{ matrix.ida_sdk_ref }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', '.github/workflows/build.yml') }}-
 
       - name: Cache ccache
         if: runner.os != 'Windows'
         uses: actions/cache@v6
         with:
           path: ~/.ccache
-          key: ccache-v1-${{ runner.os }}-${{ matrix.name }}-${{ env.IDA_SDK_STABLE_REF }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'ida-cmake/**', 'src/**', '.github/workflows/build.yml') }}
+          key: ccache-v1-${{ runner.os }}-${{ matrix.name }}-${{ matrix.ida_sdk_ref }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'ida-cmake/**', 'src/**', '.github/workflows/build.yml') }}
           restore-keys: |
-            ccache-v1-${{ runner.os }}-${{ matrix.name }}-${{ env.IDA_SDK_STABLE_REF }}-
+            ccache-v1-${{ runner.os }}-${{ matrix.name }}-${{ matrix.ida_sdk_ref }}-
 
       - name: Set environment variables (Unix)
         if: runner.os != 'Windows'
@@ -350,7 +358,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: ${{ env.IDA_SDK_REPO }}
-          ref: ${{ env.IDA_SDK_STABLE_REF }}
+          ref: ${{ env.IDA_SDK_WINDOWS_COMPAT_REF }}
           path: ida-sdk
           submodules: recursive
 
@@ -441,17 +449,17 @@ jobs:
         uses: actions/cache@v6
         with:
           path: out/build/windows-clang-release
-          key: build-v3-linux-windows-clang-${{ env.IDA_SDK_STABLE_REF }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', '.github/workflows/build.yml') }}-${{ hashFiles('src/**') }}
+          key: build-v3-linux-windows-clang-${{ env.IDA_SDK_WINDOWS_COMPAT_REF }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', '.github/workflows/build.yml') }}-${{ hashFiles('src/**') }}
           restore-keys: |
-            build-v3-linux-windows-clang-${{ env.IDA_SDK_STABLE_REF }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', '.github/workflows/build.yml') }}-
+            build-v3-linux-windows-clang-${{ env.IDA_SDK_WINDOWS_COMPAT_REF }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', '.github/workflows/build.yml') }}-
 
       - name: Cache ccache
         uses: actions/cache@v6
         with:
           path: ~/.ccache
-          key: ccache-v1-linux-windows-clang-${{ env.IDA_SDK_STABLE_REF }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', 'src/**', '.github/workflows/build.yml') }}
+          key: ccache-v1-linux-windows-clang-${{ env.IDA_SDK_WINDOWS_COMPAT_REF }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'ida-cmake/**', 'src/**', '.github/workflows/build.yml') }}
           restore-keys: |
-            ccache-v1-linux-windows-clang-${{ env.IDA_SDK_STABLE_REF }}-
+            ccache-v1-linux-windows-clang-${{ env.IDA_SDK_WINDOWS_COMPAT_REF }}-
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,9 @@ jobs:
       matrix:
         include:
           # IDA stable builds
-          # Build x86_64 on the newer Apple Silicon image: Z3 4.16 uses
-          # C++20 aggregate initialization that older Xcode images reject.
-          - os: macos-latest
+          # Run x86_64 binaries natively. macos-latest is now ARM64, where
+          # clean Rosetta executions reproducibly SIGBUS in mba_catalog.
+          - os: macos-15-intel
             name: macos-x86_64
             cmake_arch: x86_64
             rust_target: x86_64-apple-darwin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,8 +293,9 @@ message(STATUS
 include(${CMAKE_CURRENT_LIST_DIR}/ida-cmake/bootstrap.cmake)
 find_package(idasdk REQUIRED)
 
-# Match idax's fail-fast SDK check. CI pins the corresponding release-patch
-# commit; caller-owned IDASDK overrides must still resolve to the 9.4 ABI.
+# CI pins the base IDA 9.4 release SDK so release binaries retain the original
+# 9.4 export set. Caller-owned IDASDK overrides must still resolve to that ABI
+# version; CI additionally rejects imports introduced by later SDK patches.
 set(CHERNOBOG_REQUIRED_IDA_SDK_VERSION 940)
 if(NOT DEFINED IDASDK OR NOT EXISTS "${IDASDK}/include/pro.h")
     message(FATAL_ERROR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,9 +293,10 @@ message(STATUS
 include(${CMAKE_CURRENT_LIST_DIR}/ida-cmake/bootstrap.cmake)
 find_package(idasdk REQUIRED)
 
-# CI pins the base IDA 9.4 release SDK so release binaries retain the original
-# 9.4 export set. Caller-owned IDASDK overrides must still resolve to that ABI
-# version; CI additionally rejects imports introduced by later SDK patches.
+# Windows CI pins the base IDA 9.4 release SDK so release DLLs retain the
+# original 9.4 export set. Caller-owned IDASDK overrides must still resolve to
+# that ABI version; Windows CI additionally rejects imports introduced by
+# later SDK patches.
 set(CHERNOBOG_REQUIRED_IDA_SDK_VERSION 940)
 if(NOT DEFINED IDASDK OR NOT EXISTS "${IDASDK}/include/pro.h")
     message(FATAL_ERROR

--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ Notes:
 GitHub Actions builds native Linux ARM64, Windows x86-64, and Windows ARM64
 release artifacts. Windows releases use the Visual Studio generator and MSVC
 on native Windows runners, and CI verifies both the PE machine type and the
-base IDA 9.4 register-finder import. The ARM64 jobs select
+base IDA 9.4 register-finder import. Unix builds retain the current IDA 9.4 SDK
+patch and its matching runtime stubs; the ABI-compatible base SDK pin is
+Windows-specific. The ARM64 jobs select
 `aarch64-unknown-linux-gnu` and `aarch64-pc-windows-msvc`, respectively. Unix
 CI runs the portable CTest suite; Windows CI disables it because the SDK
 checkout does not include the IDA runtime DLL required by the catalog test

--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ dirty.
 
 Windows builds can be cross-compiled with `clang-cl` targeting
 `x86_64-pc-windows-msvc`; no MinGW GCC toolchain or GitHub Windows runner is
-required.
+required. This remains a local and manually-dispatched compatibility build;
+published Windows release artifacts are compiled natively with MSVC.
 
 ```bash
 # Prepare an xwin CRT/SDK sysroot once
@@ -242,15 +243,16 @@ make all-platforms
 Notes:
 
 - Linux builds run in Docker on non-Linux hosts and require `docker`.
-- Windows builds still use the local `clang-cl` + `xwin` flow above.
+- The local all-platform command uses the `clang-cl` + `xwin` flow above.
 
-GitHub Actions also builds native Linux ARM64 and Windows ARM64 release
-artifacts on the `ubuntu-24.04-arm` and `windows-11-arm` hosted runners. The
-ARM64 jobs select `aarch64-unknown-linux-gnu` and
-`aarch64-pc-windows-msvc`, respectively, and reject artifacts whose ELF or PE
-machine type does not match ARM64. Unix CI runs the portable CTest suite;
-Windows CI disables it because the SDK checkout does not include the IDA
-runtime DLL required by the catalog test executable.
+GitHub Actions builds native Linux ARM64, Windows x86-64, and Windows ARM64
+release artifacts. Windows releases use the Visual Studio generator and MSVC
+on native Windows runners, and CI verifies both the PE machine type and the
+base IDA 9.4 register-finder import. The ARM64 jobs select
+`aarch64-unknown-linux-gnu` and `aarch64-pc-windows-msvc`, respectively. Unix
+CI runs the portable CTest suite; Windows CI disables it because the SDK
+checkout does not include the IDA runtime DLL required by the catalog test
+executable.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -252,9 +252,10 @@ base IDA 9.4 register-finder import. Unix builds retain the current IDA 9.4 SDK
 patch and its matching runtime stubs; the ABI-compatible base SDK pin is
 Windows-specific. The ARM64 jobs select
 `aarch64-unknown-linux-gnu` and `aarch64-pc-windows-msvc`, respectively. Unix
-CI runs the portable CTest suite; Windows CI disables it because the SDK
-checkout does not include the IDA runtime DLL required by the catalog test
-executable.
+CI runs the portable CTest suite; the macOS x86-64 job uses the native
+`macos-15-intel` runner instead of executing its tests through Rosetta. Windows
+CI disables the tests because the SDK checkout does not include the IDA runtime
+DLL required by the catalog test executable.
 
 ## Installation
 

--- a/tests/verify_windows_pe.py
+++ b/tests/verify_windows_pe.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Verify architecture and ABI-sensitive imports of a Windows plugin PE."""
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+
+MACHINES = {
+    "amd64": 0x8664,
+    "arm64": 0xAA64,
+}
+
+
+class PEError(ValueError):
+    pass
+
+
+def unpack_from(fmt, image, offset):
+    size = struct.calcsize(fmt)
+    if offset < 0 or offset + size > len(image):
+        raise PEError("truncated PE structure at file offset 0x%X" % offset)
+    return struct.unpack_from(fmt, image, offset)
+
+
+def c_string(image, offset):
+    if offset < 0 or offset >= len(image):
+        raise PEError("string offset 0x%X is outside the file" % offset)
+    end = image.find(b"\0", offset)
+    if end < 0:
+        raise PEError("unterminated string at file offset 0x%X" % offset)
+    try:
+        return image[offset:end].decode("ascii")
+    except UnicodeDecodeError as error:
+        raise PEError("non-ASCII PE name at file offset 0x%X" % offset) from error
+
+
+class PEImage:
+    def __init__(self, path):
+        self.path = Path(path)
+        self.image = self.path.read_bytes()
+        if len(self.image) < 0x40 or self.image[:2] != b"MZ":
+            raise PEError("missing DOS header")
+
+        self.pe_offset = unpack_from("<I", self.image, 0x3C)[0]
+        if self.image[self.pe_offset:self.pe_offset + 4] != b"PE\0\0":
+            raise PEError("missing PE signature")
+
+        coff = self.pe_offset + 4
+        self.machine, self.section_count = unpack_from("<HH", self.image, coff)
+        self.optional_size = unpack_from("<H", self.image, coff + 16)[0]
+        self.optional_offset = coff + 20
+        magic = unpack_from("<H", self.image, self.optional_offset)[0]
+        if magic == 0x20B:
+            self.thunk_size = 8
+            self.ordinal_mask = 1 << 63
+            directory_offset = self.optional_offset + 112
+            directory_count_offset = self.optional_offset + 108
+        elif magic == 0x10B:
+            self.thunk_size = 4
+            self.ordinal_mask = 1 << 31
+            directory_offset = self.optional_offset + 96
+            directory_count_offset = self.optional_offset + 92
+        else:
+            raise PEError("unsupported optional-header magic 0x%X" % magic)
+
+        directory_count = unpack_from(
+            "<I", self.image, directory_count_offset)[0]
+        if directory_count < 2:
+            raise PEError("PE has no import directory")
+        self.export_rva, self.export_size = unpack_from(
+            "<II", self.image, directory_offset)
+        self.import_rva, self.import_size = unpack_from(
+            "<II", self.image, directory_offset + 8)
+        self.size_of_headers = unpack_from(
+            "<I", self.image, self.optional_offset + 60)[0]
+
+        section_offset = self.optional_offset + self.optional_size
+        self.sections = []
+        for index in range(self.section_count):
+            current = section_offset + index * 40
+            virtual_size, virtual_address, raw_size, raw_offset = unpack_from(
+                "<IIII", self.image, current + 8)
+            self.sections.append(
+                (virtual_address, max(virtual_size, raw_size), raw_offset, raw_size)
+            )
+
+    def rva_offset(self, rva):
+        if rva < self.size_of_headers:
+            return rva
+        for virtual_address, span, raw_offset, raw_size in self.sections:
+            if virtual_address <= rva < virtual_address + span:
+                delta = rva - virtual_address
+                if delta >= raw_size:
+                    raise PEError("RVA 0x%X lies outside section raw data" % rva)
+                return raw_offset + delta
+        raise PEError("RVA 0x%X is not mapped by a section" % rva)
+
+    def imports(self):
+        result = set()
+        if self.import_rva == 0:
+            return result
+        descriptor = self.rva_offset(self.import_rva)
+        while True:
+            original_thunk, timestamp, forwarder, name_rva, first_thunk = unpack_from(
+                "<IIIII", self.image, descriptor)
+            if not any((original_thunk, timestamp, forwarder, name_rva, first_thunk)):
+                break
+            dll = c_string(self.image, self.rva_offset(name_rva)).lower()
+            thunk_rva = original_thunk or first_thunk
+            thunk = self.rva_offset(thunk_rva)
+            index = 0
+            while True:
+                fmt = "<Q" if self.thunk_size == 8 else "<I"
+                value = unpack_from(fmt, self.image, thunk + index * self.thunk_size)[0]
+                if value == 0:
+                    break
+                if value & self.ordinal_mask:
+                    symbol = "#%d" % (value & 0xFFFF)
+                else:
+                    hint_name = self.rva_offset(value)
+                    symbol = c_string(self.image, hint_name + 2)
+                result.add((dll, symbol))
+                index += 1
+            descriptor += 20
+        return result
+
+    def exports(self):
+        result = set()
+        if self.export_rva == 0:
+            return result
+        directory = self.rva_offset(self.export_rva)
+        name_count = unpack_from("<I", self.image, directory + 24)[0]
+        names_rva = unpack_from("<I", self.image, directory + 32)[0]
+        names = self.rva_offset(names_rva)
+        for index in range(name_count):
+            name_rva = unpack_from("<I", self.image, names + index * 4)[0]
+            result.add(c_string(self.image, self.rva_offset(name_rva)))
+        return result
+
+
+def import_spec(value):
+    if "!" not in value:
+        raise argparse.ArgumentTypeError("import must use DLL!symbol syntax")
+    dll, symbol = value.split("!", 1)
+    if not dll or not symbol:
+        raise argparse.ArgumentTypeError("import must use DLL!symbol syntax")
+    return dll.lower(), symbol
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("image", type=Path)
+    parser.add_argument("--machine", choices=sorted(MACHINES), required=True)
+    parser.add_argument("--require-import", action="append", type=import_spec,
+                        default=[])
+    parser.add_argument("--forbid-import", action="append", type=import_spec,
+                        default=[])
+    parser.add_argument("--require-export", action="append", default=[])
+    arguments = parser.parse_args()
+
+    try:
+        pe = PEImage(arguments.image)
+        imports = pe.imports()
+        exports = pe.exports()
+    except (OSError, PEError) as error:
+        print("PE verification failed: %s" % error, file=sys.stderr)
+        return 1
+
+    expected_machine = MACHINES[arguments.machine]
+    failures = []
+    if pe.machine != expected_machine:
+        failures.append(
+            "machine 0x%04X, expected %s (0x%04X)"
+            % (pe.machine, arguments.machine, expected_machine)
+        )
+    for required in arguments.require_import:
+        if required not in imports:
+            failures.append("missing import %s!%s" % required)
+    for forbidden in arguments.forbid_import:
+        if forbidden in imports:
+            failures.append("forbidden import %s!%s" % forbidden)
+    for required in arguments.require_export:
+        if required not in exports:
+            failures.append("missing export %s" % required)
+
+    if failures:
+        for failure in failures:
+            print("PE verification failed: %s" % failure, file=sys.stderr)
+        return 1
+
+    print(
+        "PE verification passed: machine=%s imports=%d exports=%d image=%s"
+        % (arguments.machine, len(imports), len(exports), arguments.image)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed
- build Windows x86-64 and ARM64 release artifacts natively with MSVC
- use the base IDA 9.4 SDK ABI for Windows while retaining the patched 9.4 SDK and matching runtime stubs on Unix
- verify each Windows DLL's PE machine, `PLUGIN` export, required `ida.dll!find_reg_value_info` import, and absence of `ida.dll!reg_finder94_find_reg_value_info`
- retain the Clang cross-build only as a manually dispatched compatibility check
- run macOS x86-64 builds/tests on the supported native `macos-15-intel` runner instead of through Rosetta

## Root cause
The published v6.0.1 Windows DLLs imported `ida.dll!reg_finder94_find_reg_value_info`. That entry point was introduced by a later SDK patch and is absent from the reporter's IDA 9.4 build (260713), producing `STATUS_ENTRYPOINT_NOT_FOUND (0xC0000139)`. Switching compilers alone would not remove that incompatible import.

During validation, clean x86-64 macOS test binaries reproducibly raised `SIGBUS` under Rosetta on the ARM64 `macos-latest` runner. The same full suite passes on native `macos-15-intel`.

## Validation
- [final GitHub Actions run 29761170333](https://github.com/19h/chernobog/actions/runs/29761170333): all six platform builds passed
- `actionlint .github/workflows/build.yml`
- workflow YAML and six-entry SDK-selection invariant checks
- local CTest: 4/4 passed
- release DLLs downloaded again and independently verified byte-for-byte against final CI artifacts

## v6.0.1 release repair
- published `chernobog_windows-x86_64.dll`: SHA-256 `6795031696acbac72900bced6e4f524a7aad842014d45093750a7d154b6febde`
- replaced `chernobog_windows-arm64.dll`: SHA-256 `8c79083e1ee83caa0973d4ad750ed27635ce75aab8872a40d954317eb97d32b1`
- removed obsolete `chernobog_windows-x86_64-clang.dll`
- non-Windows v6.0.1 assets were not modified